### PR TITLE
Speed up auxiliar method calculation by performing it post-optimization

### DIFF
--- a/pulpo/utils/converter.py
+++ b/pulpo/utils/converter.py
@@ -8,6 +8,9 @@ def combine_inputs(lci_data, demand, choices, upper_limit, lower_limit, methods)
     technosphere = lci_data['technosphere']
     activity_map = lci_data['activity_map']
 
+    ''' Remove matrices that are not part of the objective '''
+    matrices = {h: matrices[h] for h in matrices if str(h) in methods}
+
     ''' Prepare the environmental impact matrices Q[h]*B'''
     env_cost = {h: sparse.csr_matrix.dot(matrices[h], biosphere) for h in matrices}
 

--- a/pulpo/utils/optimizer.py
+++ b/pulpo/utils/optimizer.py
@@ -91,6 +91,27 @@ def objective_function(model):
     """Objective is a sum over all indicators with weights. Typically, the indicator of study has weight 1, the rest 0"""
     return sum(model.impacts[h] * model.WEIGHTS[h] for h in model.INDICATOR)
 
+def calculate_methods(instance, lci_data, methods):
+    '''
+    This function calculates the impacts if a method with weight 0 has been specified
+    '''
+    import scipy.sparse as sparse
+    import numpy as np
+    matrices = lci_data['matrices']
+    biosphere = lci_data['biosphere']
+    matrices = {h: matrices[h] for h in matrices if str(h) in methods}
+    env_cost = {h: sparse.csr_matrix.dot(matrices[h], biosphere) for h in matrices}
+    try:
+        scaling_vector = np.array([instance.scaling_vector[x].value for x in instance.scaling_vector])
+    except:
+        scaling_vector = np.array([instance.scaling_vector[x] for x in instance.scaling_vector])
+    impacts = {}
+    for h in matrices:
+        impacts[h] = sum(env_cost[h].dot(scaling_vector))
+    instance.impacts_calculated = pyo.Var([h for h in impacts], initialize=impacts)
+    return instance
+
+
 
 def instantiate(model_data):
     """ This function builds an instance of the optimization model with specific data and objective function"""

--- a/pulpo/utils/saver.py
+++ b/pulpo/utils/saver.py
@@ -82,6 +82,17 @@ def summarize_results(instance, project, database, choices, constraints, demand,
                 data = [(k, v) for k, v in v._data.items()]
                 df = pd.DataFrame(data, columns=['Key', 'Value'])
             df.sort_values(by=['Value'], inplace=True, ascending=False)
+            print('\nThese are the impacts contained in the objective:')
+            display(df)
+
+        if v.name == 'impacts_calculated':
+            try:
+                data = [(k, map[k], v) for k, v in v._data.items()]
+                df = pd.DataFrame(data, columns=['ID', 'Activity', 'Value'])
+            except:
+                data = [(k, v) for k, v in v._data.items()]
+                df = pd.DataFrame(data, columns=['Key', 'Value'])
+            df.sort_values(by=['Value'], inplace=True, ascending=False)
             print('\nThe following impacts were calculated: ')
             display(df)
 


### PR DESCRIPTION
Speed up the calculations by performing auxiliar method evaluation post-optimization. Changes to all major module except for the parser needed to be done, excluding the "0" methods during conversion, adding an if clause in the "solve" function to check if auxiliar methods have been specified, and adding a "calculate_methods()" function to the optimizer, where the matrix multiplication of scaling vector and Q*B is performed. The summary function had to be adjusted to plot the "impacts_calculated" as opposed to the objective "impacts".