### PR TITLE
Enable use of bw25 in PULPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,70 @@
 <div align="center">
-<h1 align="center">
-<img src="https://github.com/flechtenberg/flechtenberg_images/blob/main/Pulpo-Logo_INKSCAPE.png?raw=true" width="300" />
-<h3>◦ Python-based User-defined Lifecycle Production Optimization!</h3>
-<h3>◦ Developed with the software and tools below.</h3>
 
-<p align="center">
-<img src="https://img.shields.io/badge/Jupyter-F37626.svg?style&logo=Jupyter&logoColor=white" alt="Jupyter" />
-<img src="https://img.shields.io/badge/Python-3776AB.svg?style&logo=Python&logoColor=white" alt="Python" />
-<img src="https://img.shields.io/badge/Markdown-000000.svg?style&logo=Markdown&logoColor=white" alt="Markdown" />
-</p>
-<img src="https://img.shields.io/github/license/flechtenberg/pulpo?style=flat&color=5D6D7E" alt="GitHub license" />
-<img src="https://img.shields.io/github/last-commit/flechtenberg/pulpo?style=flat&color=5D6D7E" alt="git-last-commit" />
-<img src="https://img.shields.io/github/commit-activity/m/flechtenberg/pulpo?style=flat&color=5D6D7E" alt="GitHub commit activity" />
-<img src="https://img.shields.io/github/languages/top/flechtenberg/pulpo?style=flat&color=5D6D7E" alt="GitHub top language" />
+<img src="https://github.com/flechtenberg/flechtenberg_images/blob/main/Pulpo-Logo_INKSCAPE.png?raw=true" width="300" />
+
+<h3>Python-based User-defined Lifecycle Production Optimization</h3>
+
+<!-- Development Tools -->
+[![Jupyter](https://img.shields.io/badge/Jupyter-F37626.svg?style=flat&logo=Jupyter&logoColor=white)](https://jupyter.org/)
+[![Python](https://img.shields.io/badge/Python-3776AB.svg?style=flat&logo=Python&logoColor=white)](https://www.python.org/)
+[![Markdown](https://img.shields.io/badge/Markdown-000000.svg?style=flat&logo=Markdown&logoColor=white)](https://www.markdownguide.org/)
+
+<!-- Project Metadata -->
+[![License](https://img.shields.io/github/license/flechtenberg/pulpo?style=flat&color=5D6D7E)](https://github.com/flechtenberg/pulpo/blob/main/LICENSE)
+[![Last Commit](https://img.shields.io/github/last-commit/flechtenberg/pulpo?style=flat&color=5D6D7E)](https://github.com/flechtenberg/pulpo/commits/main)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/flechtenberg/pulpo?style=flat&color=5D6D7E)](https://github.com/flechtenberg/pulpo/pulse)
+[![Top Language](https://img.shields.io/github/languages/top/flechtenberg/pulpo?style=flat&color=5D6D7E)](https://github.com/flechtenberg/pulpo)
+
+<!-- Additional -->
+[![PyPI - Version](https://img.shields.io/pypi/v/pulpo-dev?color=%2300549f)](https://pypi.org/project/pulpo-dev/)
+[![GitHub Stars](https://img.shields.io/github/stars/flechtenberg/pulpo?style=flat&color=FFD700)](https://github.com/flechtenberg/pulpo/stargazers)
+
 </div>
 
 ---
 
-## 📖 Table of Contents
-- [📍 Overview](#-overview)
-- [⚙️ Modules](#modules)
-- [🚀 Getting Started](#-getting-started)
-    - [🔧 Installation](#-installation)
-    - [🤖 Running pulpo](#-running-pulpo)
-    - [🧪 Tests](#-tests)
-- [🛣 Roadmap](#-roadmap)
-- [🤝 Contributing](#-contributing)
-- [📄 License](#-license)
-- [👏 Acknowledgments](#-acknowledgments)
-
----
-
-
 ## 📍 Overview
 
-Pulpo is a comprehensive Life Cycle Optimization (LCO) tool designed to streamline the optimization of environmental impacts across the entire lifecycle of products. It facilitates the import of data from the LCI databases accessed via brightway, converts inputs into optimization-ready formats, defines and solves optimization models using the Pyomo package, and saves and summarizes results. Pulpo empowers users to efficiently optimize and analyze environmental impacts, supporting sustainable decision-making through lifecycle-based strategies.
+This is a python package for **[Life Cycle Optimization (LCO)](https://onlinelibrary.wiley.com/doi/full/10.1111/jiec.13561)** based on life cycle inventories. `pulpo` is intended to serve as a platform for optimization tasks of varying complexity.   
+
+The package builds on top of the **[Brightway LCA framework](https://docs.brightway.dev/en/latest)** as well as the **[optimization modeling framework Pyomo](https://www.pyomo.org/)**.
 
 ---
 
-## ⚙️ Modules
+## ✨ Capabilities
 
-<details closed><summary>Root</summary>
+Applying optimization is recommended when the system of study has (1) many degrees of freedoms which would prompt the manual assessment of a manifold of scenarios, although only the "optimal" one is of interest and/or (2) any of the following capabilities makes sense within the goal and scope of the study:
 
-| File                                                                                                         | Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ---                                                                                                          | ---                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| [.gitconfig](https://github.com/flechtenberg/pulpo/blob/main/.gitconfig)                                     | This code fragment configures a git filter to clean Jupyter Notebook files in the.gitconfig file. It uses the Jupyter nbconvert command to remove the output cells and smudge to display the file's contents.                                                                                                                                                                                                                                                                                                                                             |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| [pulpo.py](https://github.com/flechtenberg/pulpo/blob/main/pulpo\pulpo.py)                                   | The code implements a PulpoOptimizer class that provides functionalities for data import, optimization, solving, retrieval, saving and summarizing results related to life cycle assessments. It uses modules like optimizer, bw_parser, converter, and saver for different operations.                                                                                                                                                                                                                                                                   |
-| [bw_parser.py](https://github.com/flechtenberg/pulpo/blob/main/pulpo\utils\bw_parser.py)                     | The code in `bw_parser.py` provides functions for importing, saving, and retrieving life cycle inventory (LCI) data from the Ecoinvent database using the Brightway2 library. It includes functions for importing data, checking if data needs to be reloaded, performing LCA calculations, saving LCI data to files, and reading LCI data from files. Additionally, it provides functions for retrieving activities and environmental flows from the database based on specified criteria. |
-| [converter.py](https://github.com/flechtenberg/pulpo/blob/main/pulpo\utils\converter.py)                     | The code in pulpo\utils\converter.py combines various inputs into a dictionary for an optimization model. It converts sparse matrices to dictionaries, modifies the technosphere matrix, creates sets, specifies demand, limits, and supply, assigns weights, and assembles the final data dictionary for the model. This function serves as a crucial step in preparing the inputs for the optimization process.                                                                                                                                         |
-| [optimizer.py](https://github.com/flechtenberg/pulpo/blob/main/pulpo\utils\optimizer.py)                     | The code defines an optimization model using the pyomo package. It includes sets, parameters, variables, constraints, and an objective function. The model is created and solved using different solvers.                                                                                                                                                                                                                                                                                                                                                 |
-| [saver.py](https://github.com/flechtenberg/pulpo/blob/main/pulpo\utils\saver.py)                             | The code provides two main functionalities:1. save_results: Saves the results of a Pyomo model to an Excel file, including raw results, metadata, and constraints.2. summarize_results: Prints a summary of the model results, including demand, impacts, choices, and constraints.                                                                                                                                                                                                                                                                       |
+- **Specify technology and regional choices** throughout the entire supply chain (i.e. fore- and background), such as choices for the production technology of electricity or origin of metal resources. Consistently accounting for changes in the background in "large scale" decisions [can be significant](https://www.sciencedirect.com/science/article/pii/S2352550924002422). 
+- **Specify constraints** on any activity in the life cycle inventories, which can be interpreted as tangible limitations such as raw material availability, production capacity, or environmental regulations.
+- **Optimize for or constrain any impact category** for which the **characterization factors** are available.
+- **Specify supply values** instead of final demands, which can become relevant if only production values are available (e.g. [here](https://www.pnas.org/doi/10.1073/pnas.1821029116)).
 
-</details>
+The following features are currently under development:
+
+> - [ ] `ℹ️  Optimization under uncertainty [chance-constraints, stochastic optimization ...]`
+> - [ ] `ℹ️  Multi-objective optimization [bi-objective epsilon constrained, goal programming ...]`
+> - [ ] `ℹ️  Integration of economic and social indicators in the optimization problem formulation`
+
+> - [ ] `ℹ️  Development of a GUI for simple optimization tasks`
+> - [X] `ℹ️  Enable PULPO to work on both bw2 and bw25 projects`
+> - [ ] `ℹ️  Thorough documentation to be hosted in the docs.brightway.dev`
+
+Feature requests are more than welcome!
 
 ---
-
-## 🚀 Getting Started
 
 ### 🔧 Installation
-PULPO has been deployed to the pypi index and can now be installed via:
+PULPO has been deployed to the pypi index. Depending on the version of brightway projects you want to work on, install either the bw2 or bw25 version via:
 ```sh
-pip install pulpo-dev
+pip install pulpo-dev[bw2]
+```
+or
+```sh
+pip install pulpo-dev[bw25]
 ```
 
-
 ### 🤖 Running pulpo
-See [pypi](https://pypi.org/project/pulpo-dev/) for a description of how to use PULPO via pip.
-
 Find example notebooks for a [hydrogen case](https://github.com/flechtenberg/pulpo/blob/master/notebooks/hydrogen_showcase.ipynb), an [electricity case](https://github.com/flechtenberg/pulpo/blob/master/notebooks/electricity_showcase.ipynb), and a [plastic case](https://github.com/flechtenberg/pulpo/blob/master/notebooks/plastic_showcase.ipynb) here.
 
 There is also a "workshop" repository ([here](https://github.com/flechtenberg/pulpo_workshop)), which has been created for the Brightcon 2024 conference. It contains several notebooks that guide you through the PULPO package and its functionalities, as well as an exercise.
@@ -80,41 +78,14 @@ Calling from the package folder:
 python -m unittest discover -s tests
 ```
 
-### Updates 
-> - [ ] `ℹ️ The package is currently under development.`
-
 ---
-
-
-## 🛣 Roadmap
-
-> - [ ] `ℹ️  Task 1: Implement integer cuts to allow a fast calculation of a ranked list of best options`
-> - [ ] `ℹ️  Task 2: Implement functionality to treat uncertainty in the optimization problem (robust)`
-> - [ ] `ℹ️ ... Requests are welcome.`
-
+## What's wew in 0.1.3?
+- Enable users to work on both bw2 and bw25 projects.
 
 ---
 
 ## 🤝 Contributing
-
-Contributions are always welcome! Please follow these steps:
-1. Fork the project repository. This creates a copy of the project on your account that you can modify without affecting the original project.
-2. Clone the forked repository to your local machine using a Git client like Git or GitHub Desktop.
-3. Create a new branch with a descriptive name (e.g., `new-feature-branch` or `bugfix-issue-123`).
-```sh
-git checkout -b new-feature-branch
-```
-4. Make changes to the project's codebase.
-5. Commit your changes to your local branch with a clear commit message that explains the changes you've made.
-```sh
-git commit -m 'Implemented new feature.'
-```
-6. Push your changes to your forked repository on GitHub using the following command
-```sh
-git push origin new-feature-branch
-```
-7. Create a new pull request to the original project repository. In the pull request, describe the changes you've made and why they're necessary.
-The project maintainers will review your changes and provide feedback or merge them into the main branch.
+Contributions are very welcome. If you would like to request a feature or report a bug please [open an Issue](https://github.com/flechtenberg/pulpo/issues). If you are confident in your coding skills don't hesitate to implement your suggestions and [send a Pull Request](https://github.com/flechtenberg/pulpo/pulls).
 
 ---
 
@@ -123,13 +94,32 @@ The project maintainers will review your changes and provide feedback or merge t
 This project is licensed under the `ℹ️  BSD 3-Clause` License. See the [LICENSE](LICENSE) file for additional info.
 Copyright (c) 2024, Fabian Lechtenberg. All rights reserved.
 
+
 ---
 
 ## 👏 Acknowledgments
 
-We would like to acknowledge the authors and contributors of these main packages that pulpo is based on:
- - [pyomo](https://github.com/Pyomo/pyomo)
- - [brightway2](https://github.com/brightway-lca/brightway2)
+We would like to express our gratitude to the authors and contributors of the following main packages that **PULPO** is based on:
+
+- [**pyomo**](https://github.com/Pyomo/pyomo)
+- [**brightway2**](https://github.com/brightway-lca/brightway2)
+
+In addition, we acknowledge the pioneering ideas and contributions from the following works:
+
+- **[Computational Structure of LCA](http://link.springer.com/10.1007/978-94-015-9900-9)**
+- **[Technology Choice Model](https://pubs.acs.org/doi/10.1021/acs.est.6b04270)**
+- **[Modular LCA](http://link.springer.com/10.1007/s11367-015-1015-3)**
+
+Follow-up work, incorporating features such as top-down matrix construction for the use of entire life cycle inventory databases and supply specification, was implemented in **PULPO** and culminated in the following publication, which details the approach and outlines its implementation:
+
+> **Fabian Lechtenberg, Robert Istrate, Victor Tulus, Antonio Espuña, Moisès Graells, and Gonzalo Guillén‐Gosálbez.**  
+> “PULPO: A Framework for Efficient Integration of Life Cycle Inventory Models into Life Cycle Product Optimization.”  
+> *Journal of Industrial Ecology*, October 10, 2024.  
+> [https://doi.org/10.1111/jiec.13561](https://doi.org/10.1111/jiec.13561)
+
+
+This article is to be cited / referred to if PULPO is used to derive results of a publication or project.
+
 ---
 ## Authors
 - [@flechtenberg](https://www.github.com/flechtenberg)

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,5 +1,5 @@
 [.ShellClassInfo]
-IconResource=C:\Users\Usuario\Pictures\Icons\Pulpo_small (1).ico,0
+IconResource=C:\Users\flechtenberg\Pictures\Icons\Pulpo_small (1).ico,0
 [ViewState]
 Mode=
 Vid=

--- a/notebooks/electricity_showcase.ipynb
+++ b/notebooks/electricity_showcase.ipynb
@@ -148,16 +148,7 @@
      "start_time": "2024-12-17T15:37:33.353602Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{('IPCC 2013', 'climate change', 'GWP 100a'): <Compressed Sparse Row sparse matrix of dtype 'float64'\n",
-      "\twith 82 stored elements and shape (2171, 2171)>}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pulpo_worker.get_lci_data()"
    ]
@@ -318,11 +309,11 @@
     {
      "data": {
       "text/plain": [
-       "['market for electricity, high voltage' (kilowatt hour, IN-Northern grid, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, GT, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, PL, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, ID, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, BR-Northern grid, None)]"
+       "['market for electricity, high voltage' (kilowatt hour, LU, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, GB, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, RO, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, BW, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, ZA, None)]"
       ]
      },
      "execution_count": 8,
@@ -349,11 +340,11 @@
     {
      "data": {
       "text/plain": [
-       "['electricity production, wind, 1-3MW turbine, onshore' (kilowatt hour, DE, None),\n",
-       " 'electricity production, natural gas, conventional power plant' (kilowatt hour, CN-ZJ, None),\n",
-       " 'electricity production, wind, >3MW turbine, onshore' (kilowatt hour, US-HICC, None),\n",
-       " 'treatment of blast furnace gas, in power plant' (kilowatt hour, CA-PE, None),\n",
-       " 'electricity, high voltage, import from RO' (kilowatt hour, MD, None)]"
+       "['treatment of blast furnace gas, in power plant' (kilowatt hour, GB, None),\n",
+       " 'electricity production, oil' (kilowatt hour, CN-GZ, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, CU, None),\n",
+       " 'electricity production, hard coal' (kilowatt hour, CN-SH, None),\n",
+       " 'electricity, high voltage, production mix' (kilowatt hour, CA-PE, None)]"
       ]
      },
      "execution_count": 9,
@@ -489,10 +480,10 @@
     {
      "data": {
       "text/plain": [
-       "['electricity production, nuclear, pressure water reactor' (kilowatt hour, DE, None),\n",
-       " 'electricity production, wind, 1-3MW turbine, onshore' (kilowatt hour, DE, None),\n",
+       "['electricity production, lignite' (kilowatt hour, DE, None),\n",
+       " 'electricity production, nuclear, pressure water reactor' (kilowatt hour, DE, None),\n",
        " 'electricity production, hard coal' (kilowatt hour, DE, None),\n",
-       " 'electricity production, lignite' (kilowatt hour, DE, None)]"
+       " 'electricity production, wind, 1-3MW turbine, onshore' (kilowatt hour, DE, None)]"
       ]
      },
      "execution_count": 14,
@@ -620,7 +611,7 @@
       "GAMS solvers library availability: True\n",
       "Solver path: C:\\APPS\\GAMS\\win64\\40.1\\gams.exe\n",
       "\n",
-      "GAMS WORKING DIRECTORY: C:\\Users\\FLECHT~1\\AppData\\Local\\Temp\\tmpo4fhnk96\n",
+      "GAMS WORKING DIRECTORY: C:\\Users\\FLECHT~1\\AppData\\Local\\Temp\\tmpqzn5u0my\n",
       "\n"
      ]
     }

--- a/notebooks/electricity_showcase.ipynb
+++ b/notebooks/electricity_showcase.ipynb
@@ -49,9 +49,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "606b78ed",
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -81,9 +85,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "ead64289",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-18T10:01:56.272770400Z",
+     "start_time": "2024-12-17T15:37:33.257637Z"
+    }
+   },
    "outputs": [],
    "source": [
     "project = \"pulpo\"\n",
@@ -95,7 +104,7 @@
     "directory = os.path.join(notebook_dir, 'data')\n",
     "\n",
     "# Substitute with your GAMS path\n",
-    "GAMS_PATH = \"C:/GAMS/37/gams.exe\""
+    "GAMS_PATH = r\"C:\\APPS\\GAMS\\win64\\40.1\\gams.exe\""
    ]
   },
   {
@@ -108,9 +117,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "ae4b5787",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-18T10:01:56.276762Z",
+     "start_time": "2024-12-17T15:37:33.340373Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)"
@@ -126,10 +140,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "80697078",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:37.011160Z",
+     "start_time": "2024-12-17T15:37:33.353602Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{('IPCC 2013', 'climate change', 'GWP 100a'): <Compressed Sparse Row sparse matrix of dtype 'float64'\n",
+      "\twith 82 stored elements and shape (2171, 2171)>}\n"
+     ]
+    }
+   ],
    "source": [
     "pulpo_worker.get_lci_data()"
    ]
@@ -194,9 +222,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "167a2bfb",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:37.023035Z",
+     "start_time": "2024-12-17T15:37:37.019284Z"
+    }
+   },
    "outputs": [],
    "source": [
     "keys = [\"('cutoff38', '962727b9a36bcaa186f222b29b57f6a3')\", \"('cutoff38', '473d4bb488e8f903b58203f3e5161636')\"]"
@@ -204,10 +237,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "b46fa327",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:38.423093Z",
+     "start_time": "2024-12-17T15:37:37.032839Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['market for electricity, high voltage' (kilowatt hour, ES, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, DE, None)]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pulpo_worker.retrieve_activities(keys=keys)"
    ]
@@ -230,9 +280,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "4d445dfc",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:38.437078Z",
+     "start_time": "2024-12-17T15:37:38.434209Z"
+    }
+   },
    "outputs": [],
    "source": [
     "activities = [\"market for electricity, high voltage\"]\n",
@@ -250,24 +305,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "0cb7d84f",
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:39.939393Z",
+     "start_time": "2024-12-17T15:37:38.450640Z"
+    },
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['market for electricity, high voltage' (kilowatt hour, IN-Northern grid, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, GT, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, PL, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, ID, None),\n",
+       " 'market for electricity, high voltage' (kilowatt hour, BR-Northern grid, None)]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pulpo_worker.retrieve_activities(activities=activities)[0:5]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "b211d17a",
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:41.367139Z",
+     "start_time": "2024-12-17T15:37:39.952262Z"
+    },
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['electricity production, wind, 1-3MW turbine, onshore' (kilowatt hour, DE, None),\n",
+       " 'electricity production, natural gas, conventional power plant' (kilowatt hour, CN-ZJ, None),\n",
+       " 'electricity production, wind, >3MW turbine, onshore' (kilowatt hour, US-HICC, None),\n",
+       " 'treatment of blast furnace gas, in power plant' (kilowatt hour, CA-PE, None),\n",
+       " 'electricity, high voltage, import from RO' (kilowatt hour, MD, None)]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pulpo_worker.retrieve_activities(reference_products=reference_products)[0:5]"
    ]
@@ -282,9 +375,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "332b2f95",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:42.719152Z",
+     "start_time": "2024-12-17T15:37:41.385314Z"
+    }
+   },
    "outputs": [],
    "source": [
     "electricity_market = pulpo_worker.retrieve_activities(activities=activities, reference_products=reference_products, locations=locations)"
@@ -292,10 +390,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "1959b64f",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:42.731441Z",
+     "start_time": "2024-12-17T15:37:42.726550Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['market for electricity, high voltage' (kilowatt hour, DE, None)]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "electricity_market"
    ]
@@ -310,9 +424,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "223e1cf1",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:42.743240Z",
+     "start_time": "2024-12-17T15:37:42.739455Z"
+    }
+   },
    "outputs": [],
    "source": [
     "demand = {electricity_market[0]: 1.28819e+11}"
@@ -336,9 +455,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "d704a9a5",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:44.043245Z",
+     "start_time": "2024-12-17T15:37:42.777555Z"
+    }
+   },
    "outputs": [],
    "source": [
     "activities = [\"electricity production, lignite\", \n",
@@ -353,10 +477,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "9d8fac69",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:44.055487Z",
+     "start_time": "2024-12-17T15:37:44.046251Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['electricity production, nuclear, pressure water reactor' (kilowatt hour, DE, None),\n",
+       " 'electricity production, wind, 1-3MW turbine, onshore' (kilowatt hour, DE, None),\n",
+       " 'electricity production, hard coal' (kilowatt hour, DE, None),\n",
+       " 'electricity production, lignite' (kilowatt hour, DE, None)]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "electricity_activities"
    ]
@@ -381,9 +524,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "bfae6af4",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:44.071741Z",
+     "start_time": "2024-12-17T15:37:44.067894Z"
+    }
+   },
    "outputs": [],
    "source": [
     "choices  = {'electricity': {electricity_activities[0]: 1e16,\n",
@@ -412,12 +560,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "be46ea2d",
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:48.909729Z",
+     "start_time": "2024-12-17T15:37:44.090006Z"
+    },
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating Instance\n",
+      "Instance created\n"
+     ]
+    }
+   ],
    "source": [
     "instance = pulpo_worker.instantiate(choices=choices, demand=demand)"
    ]
@@ -442,16 +603,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "eb13ed22",
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:37:59.112923Z",
+     "start_time": "2024-12-17T15:37:48.925367Z"
+    },
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GAMS solvers library availability: True\n",
+      "Solver path: C:\\APPS\\GAMS\\win64\\40.1\\gams.exe\n",
+      "\n",
+      "GAMS WORKING DIRECTORY: C:\\Users\\FLECHT~1\\AppData\\Local\\Temp\\tmpo4fhnk96\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
-    "results = pulpo_worker.solve()\n",
+    "#results = pulpo_worker.solve()\n",
     "# Alternatively using GAMS (cplex) solvers:\n",
-    "#results = pulpo_worker.solve(GAMS_PATH=GAMS_PATH)"
+    "results = pulpo_worker.solve(GAMS_PATH=GAMS_PATH)"
    ]
   },
   {
@@ -472,9 +649,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "cf427cea",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:38:00.644642Z",
+     "start_time": "2024-12-17T15:37:59.127619Z"
+    }
+   },
    "outputs": [],
    "source": [
     "pulpo_worker.save_results(choices=choices, demand=demand, name='electricity_showcase_results.xlsx')"
@@ -498,10 +680,185 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "f6141497",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:38:00.699492Z",
+     "start_time": "2024-12-17T15:38:00.659681Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The following demand / functional unit has been specified: \n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Demand</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>market for electricity, high voltage | electricity, high voltage | DE</th>\n",
+       "      <td>1.288190e+11</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                             Demand\n",
+       "market for electricity, high voltage | electricity, high voltage | DE  1.288190e+11"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "These are the impacts contained in the objective:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Key</th>\n",
+       "      <th>Value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>('IPCC 2013', 'climate change', 'GWP 100a')</td>\n",
+       "      <td>1.624722e+10</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                           Key         Value\n",
+       "0  ('IPCC 2013', 'climate change', 'GWP 100a')  1.624722e+10"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "The following choices were made: \n",
+      "electricity\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"3\" halign=\"left\">electricity</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>Process</th>\n",
+       "      <th>Capacity</th>\n",
+       "      <th>Value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Process 0</th>\n",
+       "      <td>electricity production, nuclear, pressure water reactor | electricity, high voltage | DE</td>\n",
+       "      <td>1.000000e+16</td>\n",
+       "      <td>8.360521e+10</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                        electricity  \\\n",
+       "                                                                                            Process   \n",
+       "Process 0  electricity production, nuclear, pressure water reactor | electricity, high voltage | DE   \n",
+       "\n",
+       "                                       \n",
+       "               Capacity         Value  \n",
+       "Process 0  1.000000e+16  8.360521e+10  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No additional constraints have been passed.\n"
+     ]
+    }
+   ],
    "source": [
     "pulpo_worker.summarize_results(choices=choices, demand=demand, zeroes=True)"
    ]
@@ -560,9 +917,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "04b68998",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:38:02.179850Z",
+     "start_time": "2024-12-17T15:38:00.743258Z"
+    }
+   },
    "outputs": [],
    "source": [
     "activities = [\"market for nuclear fuel element, for pressure water reactor, UO2 4.0% & MOX\"]\n",
@@ -574,19 +936,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "aebdc35c",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:38:02.615734Z",
+     "start_time": "2024-12-17T15:38:02.608721Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['market for nuclear fuel element, for pressure water reactor, UO2 4.0% & MOX' (kilogram, GLO, None)]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nuclear_fuel"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "a89c6ee5",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T15:38:02.761750Z",
+     "start_time": "2024-12-17T15:38:02.758220Z"
+    }
+   },
    "outputs": [],
    "source": [
     "upper_limit = {nuclear_fuel[0]: 100000}"
@@ -605,9 +988,21 @@
    "execution_count": null,
    "id": "87267aa9",
    "metadata": {
+    "ExecuteTime": {
+     "start_time": "2024-12-17T15:38:02.791255Z"
+    },
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating Instance\n",
+      "Instance created\n"
+     ]
+    }
+   ],
    "source": [
     "pulpo_worker.instantiate(choices=choices, demand=demand, upper_limit=upper_limit)\n",
     "results = pulpo_worker.solve()"
@@ -1263,7 +1658,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/electricity_showcase.ipynb
+++ b/notebooks/electricity_showcase.ipynb
@@ -85,7 +85,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
+   "id": "31a552aa-a98f-459a-9e53-e808c7ef2fe2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter version (bw2 or bw25):  bw25\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Set to: project=pulpo_bw25, database=ecoinvent-3.8-cutoff, methods=('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 100a')\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Ask the user for input\n",
+    "version = input(\"Enter version (bw2 or bw25): \")\n",
+    "\n",
+    "# Set variables based on user input\n",
+    "if version == \"bw2\":\n",
+    "    project = \"pulpo\"\n",
+    "    database = \"cutoff38\"\n",
+    "    methods = \"('IPCC 2013', 'climate change', 'GWP 100a')\"\n",
+    "elif version == \"bw25\":\n",
+    "    project = \"pulpo_bw25\"\n",
+    "    database = \"ecoinvent-3.8-cutoff\"\n",
+    "    methods = \"('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 100a')\"\n",
+    "else:\n",
+    "    raise ValueError(\"Invalid version specified. Please enter 'pulpo' or 'pulpo_bw25'.\")\n",
+    "\n",
+    "print(f\"Set to: project={project}, database={database}, methods={methods}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "ead64289",
    "metadata": {
     "ExecuteTime": {
@@ -95,10 +135,6 @@
    },
    "outputs": [],
    "source": [
-    "project = \"pulpo\"\n",
-    "database = \"cutoff38\"\n",
-    "methods = \"('IPCC 2013', 'climate change', 'GWP 100a')\"\n",
-    "\n",
     "# Substitute with your working directory of choice\n",
     "notebook_dir = os.path.dirname(os.getcwd())\n",
     "directory = os.path.join(notebook_dir, 'data')\n",
@@ -117,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "ae4b5787",
    "metadata": {
     "ExecuteTime": {
@@ -127,7 +163,9 @@
    },
    "outputs": [],
    "source": [
-    "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)"
+    "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)\n",
+    "if version==\"bw25\":\n",
+    "    pulpo_worker.intervention_matrix=\"ecoinvent-3.8-biosphere\""
    ]
   },
   {
@@ -140,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "80697078",
    "metadata": {
     "ExecuteTime": {
@@ -213,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "167a2bfb",
    "metadata": {
     "ExecuteTime": {
@@ -228,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "b46fa327",
    "metadata": {
     "ExecuteTime": {
@@ -236,19 +274,7 @@
      "start_time": "2024-12-17T15:37:37.032839Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['market for electricity, high voltage' (kilowatt hour, ES, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, DE, None)]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pulpo_worker.retrieve_activities(keys=keys)"
    ]
@@ -271,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "4d445dfc",
    "metadata": {
     "ExecuteTime": {
@@ -296,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "0cb7d84f",
    "metadata": {
     "ExecuteTime": {
@@ -305,29 +331,14 @@
     },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['market for electricity, high voltage' (kilowatt hour, LU, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, GB, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, RO, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, BW, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, ZA, None)]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pulpo_worker.retrieve_activities(activities=activities)[0:5]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "b211d17a",
    "metadata": {
     "ExecuteTime": {
@@ -336,22 +347,7 @@
     },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['treatment of blast furnace gas, in power plant' (kilowatt hour, GB, None),\n",
-       " 'electricity production, oil' (kilowatt hour, CN-GZ, None),\n",
-       " 'market for electricity, high voltage' (kilowatt hour, CU, None),\n",
-       " 'electricity production, hard coal' (kilowatt hour, CN-SH, None),\n",
-       " 'electricity, high voltage, production mix' (kilowatt hour, CA-PE, None)]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pulpo_worker.retrieve_activities(reference_products=reference_products)[0:5]"
    ]
@@ -366,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "332b2f95",
    "metadata": {
     "ExecuteTime": {
@@ -381,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "1959b64f",
    "metadata": {
     "ExecuteTime": {
@@ -389,18 +385,7 @@
      "start_time": "2024-12-17T15:37:42.726550Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['market for electricity, high voltage' (kilowatt hour, DE, None)]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "electricity_market"
    ]
@@ -415,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "223e1cf1",
    "metadata": {
     "ExecuteTime": {
@@ -446,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "d704a9a5",
    "metadata": {
     "ExecuteTime": {
@@ -468,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "9d8fac69",
    "metadata": {
     "ExecuteTime": {
@@ -476,21 +461,7 @@
      "start_time": "2024-12-17T15:37:44.046251Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['electricity production, lignite' (kilowatt hour, DE, None),\n",
-       " 'electricity production, nuclear, pressure water reactor' (kilowatt hour, DE, None),\n",
-       " 'electricity production, hard coal' (kilowatt hour, DE, None),\n",
-       " 'electricity production, wind, 1-3MW turbine, onshore' (kilowatt hour, DE, None)]"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "electricity_activities"
    ]
@@ -515,7 +486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "bfae6af4",
    "metadata": {
     "ExecuteTime": {
@@ -551,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "be46ea2d",
    "metadata": {
     "ExecuteTime": {
@@ -560,16 +531,7 @@
     },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating Instance\n",
-      "Instance created\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "instance = pulpo_worker.instantiate(choices=choices, demand=demand)"
    ]
@@ -594,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "eb13ed22",
    "metadata": {
     "ExecuteTime": {
@@ -603,19 +565,7 @@
     },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GAMS solvers library availability: True\n",
-      "Solver path: C:\\APPS\\GAMS\\win64\\40.1\\gams.exe\n",
-      "\n",
-      "GAMS WORKING DIRECTORY: C:\\Users\\FLECHT~1\\AppData\\Local\\Temp\\tmpqzn5u0my\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#results = pulpo_worker.solve()\n",
     "# Alternatively using GAMS (cplex) solvers:\n",
@@ -640,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "cf427cea",
    "metadata": {
     "ExecuteTime": {
@@ -671,7 +621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "f6141497",
    "metadata": {
     "ExecuteTime": {
@@ -679,177 +629,7 @@
      "start_time": "2024-12-17T15:38:00.659681Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The following demand / functional unit has been specified: \n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Demand</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>market for electricity, high voltage | electricity, high voltage | DE</th>\n",
-       "      <td>1.288190e+11</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                                             Demand\n",
-       "market for electricity, high voltage | electricity, high voltage | DE  1.288190e+11"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "These are the impacts contained in the objective:\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Key</th>\n",
-       "      <th>Value</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>('IPCC 2013', 'climate change', 'GWP 100a')</td>\n",
-       "      <td>1.624722e+10</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                           Key         Value\n",
-       "0  ('IPCC 2013', 'climate change', 'GWP 100a')  1.624722e+10"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "The following choices were made: \n",
-      "electricity\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead tr th {\n",
-       "        text-align: left;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th></th>\n",
-       "      <th colspan=\"3\" halign=\"left\">electricity</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th></th>\n",
-       "      <th>Process</th>\n",
-       "      <th>Capacity</th>\n",
-       "      <th>Value</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>Process 0</th>\n",
-       "      <td>electricity production, nuclear, pressure water reactor | electricity, high voltage | DE</td>\n",
-       "      <td>1.000000e+16</td>\n",
-       "      <td>8.360521e+10</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                                                        electricity  \\\n",
-       "                                                                                            Process   \n",
-       "Process 0  electricity production, nuclear, pressure water reactor | electricity, high voltage | DE   \n",
-       "\n",
-       "                                       \n",
-       "               Capacity         Value  \n",
-       "Process 0  1.000000e+16  8.360521e+10  "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "No additional constraints have been passed.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pulpo_worker.summarize_results(choices=choices, demand=demand, zeroes=True)"
    ]
@@ -908,7 +688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "04b68998",
    "metadata": {
     "ExecuteTime": {
@@ -927,7 +707,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "aebdc35c",
    "metadata": {
     "ExecuteTime": {
@@ -935,25 +715,14 @@
      "start_time": "2024-12-17T15:38:02.608721Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['market for nuclear fuel element, for pressure water reactor, UO2 4.0% & MOX' (kilogram, GLO, None)]"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nuclear_fuel"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "a89c6ee5",
    "metadata": {
     "ExecuteTime": {
@@ -984,16 +753,7 @@
     },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating Instance\n",
-      "Instance created\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pulpo_worker.instantiate(choices=choices, demand=demand, upper_limit=upper_limit)\n",
     "results = pulpo_worker.solve()"
@@ -1120,10 +880,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "methods = {\"('IPCC 2013', 'climate change', 'GWP 100a')\": 0,\n",
-    "           \"('ReCiPe Endpoint (E,A)', 'resources', 'total')\": 0,\n",
-    "           \"('ReCiPe Endpoint (E,A)', 'human health', 'total')\": 1,\n",
-    "           \"('ReCiPe Endpoint (E,A)', 'ecosystem quality', 'total')\": 0}"
+    "methods = {\n",
+    "    (f\"('ecoinvent-3.8', {k[1:]}\" if version == \"bw25\" else k): (1 if k == \"('ReCiPe Endpoint (E,A)', 'human health', 'total')\" else 0)\n",
+    "    for k in [\n",
+    "        \"('IPCC 2013', 'climate change', 'GWP 100a')\",\n",
+    "        \"('ReCiPe Endpoint (E,A)', 'resources', 'total')\",\n",
+    "        \"('ReCiPe Endpoint (E,A)', 'human health', 'total')\",\n",
+    "        \"('ReCiPe Endpoint (E,A)', 'ecosystem quality', 'total')\"\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
@@ -1141,7 +906,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)"
+    "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)\n",
+    "if version==\"bw25\":\n",
+    "    pulpo_worker.intervention_matrix=\"ecoinvent-3.8-biosphere\""
    ]
   },
   {
@@ -1224,10 +991,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "methods = {\"('IPCC 2013', 'climate change', 'GWP 100a')\": 1,\n",
-    "           \"('ReCiPe Endpoint (E,A)', 'resources', 'total')\": 0,\n",
-    "           \"('ReCiPe Endpoint (E,A)', 'human health', 'total')\": 0,\n",
-    "           \"('ReCiPe Endpoint (E,A)', 'ecosystem quality', 'total')\": 0}"
+    "methods = {\n",
+    "    (f\"('ecoinvent-3.8', {k[1:]}\" if version == \"bw25\" else k): (1 if k == \"('IPCC 2013', 'climate change', 'GWP 100a')\" else 0)\n",
+    "    for k in [\n",
+    "        \"('IPCC 2013', 'climate change', 'GWP 100a')\",\n",
+    "        \"('ReCiPe Endpoint (E,A)', 'resources', 'total')\",\n",
+    "        \"('ReCiPe Endpoint (E,A)', 'human health', 'total')\",\n",
+    "        \"('ReCiPe Endpoint (E,A)', 'ecosystem quality', 'total')\"\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
@@ -1238,6 +1010,8 @@
    "outputs": [],
    "source": [
     "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)\n",
+    "if version==\"bw25\":\n",
+    "    pulpo_worker.intervention_matrix=\"ecoinvent-3.8-biosphere\"\n",
     "pulpo_worker.get_lci_data()"
    ]
   },
@@ -1475,7 +1249,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)"
+    "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)\n",
+    "if version==\"bw25\":\n",
+    "    pulpo_worker.intervention_matrix=\"ecoinvent-3.8-biosphere\""
    ]
   },
   {
@@ -1649,7 +1425,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/notebooks/hydrogen_showcase.ipynb
+++ b/notebooks/hydrogen_showcase.ipynb
@@ -73,20 +73,41 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d116e4d4-be73-4291-a77c-603459b3ef2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ask the user for input\n",
+    "version = input(\"Enter version (bw2 or bw25): \")\n",
+    "\n",
+    "# Set variables based on user input\n",
+    "if version == \"bw2\":\n",
+    "    project = \"pulpo\"\n",
+    "    database = \"cutoff38\"\n",
+    "    method = \"('IPCC 2013', 'climate change', 'GWP 100a')\"\n",
+    "elif version == \"bw25\":\n",
+    "    project = \"pulpo_bw25\"\n",
+    "    database = \"ecoinvent-3.8-cutoff\"\n",
+    "    method = \"('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 100a')\"\n",
+    "else:\n",
+    "    raise ValueError(\"Invalid version specified. Please enter 'pulpo' or 'pulpo_bw25'.\")\n",
+    "\n",
+    "print(f\"Set to: project={project}, database={database}, methods={method}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "ead64289",
    "metadata": {},
    "outputs": [],
    "source": [
-    "project = \"pulpo\"\n",
-    "database = \"cutoff38\"\n",
-    "method = \"('IPCC 2013', 'climate change', 'GWP 100a')\"\n",
-    "\n",
     "# Substitute with your working directory of choice\n",
     "notebook_dir = os.path.dirname(os.getcwd())\n",
     "directory = os.path.join(notebook_dir, 'data')\n",
     "\n",
     "# Substitute with your GAMS path\n",
-    "GAMS_PATH = \"C:/GAMS/37/gams.exe\""
+    "GAMS_PATH = r\"C:\\APPS\\GAMS\\win64\\40.1\\gams.exe\""
    ]
   },
   {
@@ -104,7 +125,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pulpo_worker = pulpo.PulpoOptimizer(project, database, method, directory)"
+    "pulpo_worker = pulpo.PulpoOptimizer(project, database, method, directory)\n",
+    "if version==\"bw25\":\n",
+    "    pulpo_worker.intervention_matrix=\"ecoinvent-3.8-biosphere\""
    ]
   },
   {
@@ -601,8 +624,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "method = [\"('IPCC 2013', 'climate change', 'GWP 100a')\",\n",
-    "          \"('CML 2001 (superseded)', 'terrestrial ecotoxicity', 'TAETP infinite')\"]"
+    "if version==\"bw25\":\n",
+    "    methods = {\"('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 100a')\": 1,\n",
+    "          \"('ecoinvent-3.8', 'CML 2001 (superseded)', 'terrestrial ecotoxicity', 'TAETP infinite')\": 0}\n",
+    "else:\n",
+    "    methods = {\"('IPCC 2013', 'climate change', 'GWP 100a')\": 1,\n",
+    "          \"('CML 2001 (superseded)', 'terrestrial ecotoxicity', 'TAETP infinite')\": 0}"
    ]
   },
   {
@@ -612,7 +639,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pulpo_worker = pulpo.PulpoOptimizer(project, database, method, directory)"
+    "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)\n",
+    "if version==\"bw25\":\n",
+    "    pulpo_worker.intervention_matrix=\"ecoinvent-3.8-biosphere\""
    ]
   },
   {
@@ -623,17 +652,6 @@
    "outputs": [],
    "source": [
     "pulpo_worker.get_lci_data()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a1d59906",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "methods = {\"('IPCC 2013', 'climate change', 'GWP 100a')\": 0,\n",
-    "          \"('CML 2001 (superseded)', 'terrestrial ecotoxicity', 'TAETP infinite')\": 1}"
    ]
   },
   {
@@ -656,6 +674,64 @@
    "metadata": {
     "scrolled": true
    },
+   "outputs": [],
+   "source": [
+    "pulpo_worker.summarize_results(choices=choices, demand=demand, zeroes=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58aa77d0-0e9b-4b88-b6a3-84cf5701377e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if version==\"bw25\":\n",
+    "    methods = {\"('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 100a')\": 0,\n",
+    "          \"('ecoinvent-3.8', 'CML 2001 (superseded)', 'terrestrial ecotoxicity', 'TAETP infinite')\": 1}\n",
+    "else:\n",
+    "    methods = {\"('IPCC 2013', 'climate change', 'GWP 100a')\": 0,\n",
+    "          \"('CML 2001 (superseded)', 'terrestrial ecotoxicity', 'TAETP infinite')\": 1}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfbe2fe3-f3d1-46a0-9a7d-a49af4adb80d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pulpo_worker = pulpo.PulpoOptimizer(project, database, methods, directory)\n",
+    "if version==\"bw25\":\n",
+    "    pulpo_worker.intervention_matrix=\"ecoinvent-3.8-biosphere\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae7f071c-be80-44f3-ad4f-eef0c603a56e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pulpo_worker.get_lci_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46094d6d-9c62-4f46-887f-e28a8e958b85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pulpo_worker.instantiate(choices=choices, demand=demand)\n",
+    "results = pulpo_worker.solve()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ede20fa6-4883-4dd9-a14b-25faecc27bd7",
+   "metadata": {},
    "outputs": [],
    "source": [
     "pulpo_worker.summarize_results(choices=choices, demand=demand, zeroes=True)"
@@ -857,14 +933,6 @@
     "\n",
     "Overall, when specifying supply values instead of demand values, the corresponding scaling vector entries are always smaller."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b71082ce",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -883,7 +951,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/pulpo/utils/bw_parser.py
+++ b/pulpo/utils/bw_parser.py
@@ -1,26 +1,7 @@
 from typing import List, Union, Dict, Any
 import bw2calc as bc
 import bw2data as bd
-from packaging import version
-
-# Define version thresholds
-THRESHOLDS = {
-    "bw2calc": "2.0.dev5",
-    "bw2data": "4.0.dev11",
-}
-
-def is_bw25():
-    """Check if the installed Brightway packages adhere to bw25 versions."""
-    try:
-        for pkg, threshold in {"bw2calc": bc, "bw2data": bd}.items():
-            pkg_version = ".".join(map(str, threshold.__version__)) if isinstance(threshold.__version__,
-                                                                                  tuple) else str(
-                threshold.__version__)
-            if version.parse(pkg_version) < version.parse(THRESHOLDS[pkg]):
-                return False
-        return True
-    except Exception as e:
-        raise RuntimeError(f"Error checking Brightway versions: {e}")
+from pulpo.utils.tests import is_bw25
 
 def import_data(project: str, database: str, method: Union[str, List[str], dict[str, int]],
                 intervention_matrix_name: str) -> Dict[str, Union[dict, Any]]:

--- a/pulpo/utils/bw_parser.py
+++ b/pulpo/utils/bw_parser.py
@@ -76,7 +76,7 @@ def import_data(project: str, database: str, method: Union[str, List[str], dict[
     if intervention_matrix_name in bd.databases:
         eidb_bio = bd.Database(intervention_matrix_name)
         if bw25:
-            intervention_map = lca.dicts.biosphere
+            intervention_map = {act.key: lca.dicts.biosphere[act.id] for act in eidb_bio if act.id in lca.dicts.biosphere}  # TODO: This is adherring to old ways of storring data with keys ... how to work with IDs instead?
         else:
             intervention_map = lca.biosphere_dict
         for act in eidb_bio:
@@ -196,21 +196,21 @@ def retrieve_methods(project: str, sub_string: List[str]) -> List[str]:
     bd.projects.set_current(project)
     return [method for method in bd.methods if any([x.lower() in str(method).lower() for x in sub_string])]
 
-if __name__ == '__main__':
-    if is_bw25():
-        project = "pulpo_bw25"
-        biosphere = "ecoinvent-3.8-biosphere"
-        methods = {"('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 100a')": 1,
-                   "('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 20a')": 0,
-                   }
-    else:
-        project = "pulpo"
-        biosphere = "biosphere3"
-        methods = {"('IPCC 2013', 'climate change', 'GWP 100a')": 1,
-                   "('IPCC 2013', 'climate change', 'GWP 20a')": 0,
-                   }
-
-    database = "ecoinvent-3.8-cutoff"
-
-
-    import_data(project, database, methods, intervention_matrix_name=biosphere)
+#if __name__ == '__main__':
+#    if is_bw25():
+#        project = "pulpo_bw25"
+#        biosphere = "ecoinvent-3.8-biosphere"
+#        methods = {"('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 100a')": 1,
+#                   "('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 20a')": 0,
+#                   }
+#    else:
+#        project = "pulpo"
+#        biosphere = "biosphere3"
+#        methods = {"('IPCC 2013', 'climate change', 'GWP 100a')": 1,
+#                   "('IPCC 2013', 'climate change', 'GWP 20a')": 0,
+#                   }
+#
+#    database = "ecoinvent-3.8-cutoff"
+#
+#
+#    import_data(project, database, methods, intervention_matrix_name=biosphere)

--- a/pulpo/utils/bw_parser.py
+++ b/pulpo/utils/bw_parser.py
@@ -42,8 +42,8 @@ def import_data(project: str, database: str, method: Union[str, List[str], dict[
     data_objs_1 = bd.get_multilca_data_objs(functional_units=functional_units_1, method_config=config_1)
 
     lca = bc.MultiLCA(demands=functional_units_1, method_config=config_1, data_objs=data_objs_1)
-    lca.lci()
-    lca.lcia()
+    lca.load_lci_data()
+    lca.load_lcia_data()
 
     # Store the characterization (C) matrix for the method
     characterization_matrices = {str(method): lca.characterization_matrices[method] for method in methods}

--- a/pulpo/utils/bw_parser.py
+++ b/pulpo/utils/bw_parser.py
@@ -53,17 +53,15 @@ def import_data(project: str, database: str, method: Union[str, List[str], dict[
     intervention_matrix = lca.biosphere_matrix  # B matrix
 
     # Create activity map key --> ID | ID --> description
-    process_map = lca.dicts.product
+    process_map = {act.key: lca.dicts.product[act.id] for act in eidb} # TODO: This is adherring to old ways of storring data with keys ... how to work with IDs instead?
+
     for act in eidb:
-        print(process_map)
-        print(act.id)
-        print(process_map[act.id])
-        process_map[process_map[act.id]] = str(act['name']) + ' | ' + str(act['reference product']) + ' | ' + str(
+        process_map[process_map[act.key]] = str(act['name']) + ' | ' + str(act['reference product']) + ' | ' + str(
             act['location'])
 
     if intervention_matrix_name in bd.databases:
         eidb_bio = bd.Database(intervention_matrix_name)
-        intervention_map = lca.biosphere_dict
+        intervention_map = lca.dicts.biosphere
         for act in eidb_bio:
             if act.key in intervention_map:
                 intervention_map[intervention_map[act.key]] = act['name'] + ' | ' + str(act['categories'])
@@ -182,10 +180,10 @@ def retrieve_methods(project: str, sub_string: List[str]) -> List[str]:
     return [method for method in bd.methods if any([x.lower() in str(method).lower() for x in sub_string])]
 
 if __name__ == '__main__':
-    project = "pulpo"
-    database = "cutoff38"
-    methods = {"('IPCC 2013', 'climate change', 'GWP 100a')": 1,
-               "('IPCC 2013', 'climate change', 'GWP 20a')": 0,
+    project = "pulpo_bw25"
+    database = "ecoinvent-3.8-cutoff"
+    methods = {"('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 100a')": 1,
+               "('ecoinvent-3.8', 'IPCC 2013', 'climate change', 'GWP 20a')": 0,
                }
 
-    import_data(project, database, methods, 'biosphere3')
+    import_data(project, database, methods, 'ecoinvent-3.8-biosphere')

--- a/pulpo/utils/bw_parser.py
+++ b/pulpo/utils/bw_parser.py
@@ -1,7 +1,7 @@
 from typing import List, Union, Dict, Any
 import bw2calc as bc
 import bw2data as bd
-from pulpo.utils.tests import is_bw25
+from pulpo.utils.utils import is_bw25
 
 def import_data(project: str, database: str, method: Union[str, List[str], dict[str, int]],
                 intervention_matrix_name: str) -> Dict[str, Union[dict, Any]]:

--- a/pulpo/utils/tests.py
+++ b/pulpo/utils/tests.py
@@ -1,8 +1,29 @@
 import bw2data as bd
+import bw2calc as bc
 import copy
+from packaging import version
+
+def is_bw25():
+    """Check if the installed Brightway packages adhere to bw25 versions."""
+    # Define version thresholds
+    THRESHOLDS = {
+        "bw2calc": "2.0.dev5",
+        "bw2data": "4.0.dev11",
+    }
+
+    try:
+        for pkg, threshold in {"bw2calc": bc, "bw2data": bd}.items():
+            pkg_version = ".".join(map(str, threshold.__version__)) if isinstance(threshold.__version__,
+                                                                                  tuple) else str(
+                threshold.__version__)
+            if version.parse(pkg_version) < version.parse(THRESHOLDS[pkg]):
+                return False
+        return True
+    except Exception as e:
+        raise RuntimeError(f"Error checking Brightway versions: {e}")
+
 import pulpo as pulpo
 from pulpo.utils.bw_parser import import_data, retrieve_methods, retrieve_env_interventions, retrieve_processes
-from pulpo import pulpo
 
 def setup_test_db():
     # Set the current project to "sample_project"

--- a/pulpo/utils/tests.py
+++ b/pulpo/utils/tests.py
@@ -1,27 +1,6 @@
 import bw2data as bd
 import bw2calc as bc
 import copy
-from packaging import version
-
-def is_bw25():
-    """Check if the installed Brightway packages adhere to bw25 versions."""
-    # Define version thresholds
-    THRESHOLDS = {
-        "bw2calc": "2.0.dev5",
-        "bw2data": "4.0.dev11",
-    }
-
-    try:
-        for pkg, threshold in {"bw2calc": bc, "bw2data": bd}.items():
-            pkg_version = ".".join(map(str, threshold.__version__)) if isinstance(threshold.__version__,
-                                                                                  tuple) else str(
-                threshold.__version__)
-            if version.parse(pkg_version) < version.parse(THRESHOLDS[pkg]):
-                return False
-        return True
-    except Exception as e:
-        raise RuntimeError(f"Error checking Brightway versions: {e}")
-
 import pulpo as pulpo
 from pulpo.utils.bw_parser import import_data, retrieve_methods, retrieve_env_interventions, retrieve_processes
 

--- a/pulpo/utils/utils.py
+++ b/pulpo/utils/utils.py
@@ -1,0 +1,22 @@
+import bw2data as bd
+import bw2calc as bc
+from packaging import version
+
+def is_bw25():
+    """Check if the installed Brightway packages adhere to bw25 versions."""
+    # Define version thresholds
+    THRESHOLDS = {
+        "bw2calc": "2.0.dev5",
+        "bw2data": "4.0.dev11",
+    }
+
+    try:
+        for pkg, threshold in {"bw2calc": bc, "bw2data": bd}.items():
+            pkg_version = ".".join(map(str, threshold.__version__)) if isinstance(threshold.__version__,
+                                                                                  tuple) else str(
+                threshold.__version__)
+            if version.parse(pkg_version) < version.parse(THRESHOLDS[pkg]):
+                return False
+        return True
+    except Exception as e:
+        raise RuntimeError(f"Error checking Brightway versions: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 bw2calc==1.8.2
 bw2data==3.6.6
 fs==2.4.16
-pyomo<=6.6.2
+pyomo==6.8.2
 highspy==1.8.0
 ipython==8.14.0
 jupyter
 tqdm
+xlsxwriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-bw2calc==1.8.2
-bw2data==3.6.6
+bw2calc==2.0.1
+bw2data==4.3.0
 fs==2.4.16
 pyomo==6.8.2
 highspy==1.8.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 # Open and read the contents of the README file
-with open('README_pypi.md', 'r', encoding='utf-8') as readme_file:
+with open('README.md', 'r', encoding='utf-8') as readme_file:
     long_description = readme_file.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ with open('README_pypi.md', 'r', encoding='utf-8') as readme_file:
 
 setup(
     name="pulpo-dev",
-    version="0.1.2",
-    description="pulpo package for optimization in LCI databases",
+    version="0.1.3",
+    description="Pulpo package for optimization in LCI databases",
     author="Fabian Lechtenberg",
-    author_email="fabian.lechtenberg@upc.edu",
+    author_email="fabian.lechtenberg@chem.ethz.ch",
     url="https://github.com/flechtenberg/pulpo",
     classifiers=[
         "Programming Language :: Python :: 3",
@@ -17,16 +17,28 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(),
-    python_requires=">=3.10, <=3.12",
+    python_requires=">=3.10, <3.13",
     install_requires=[
-        "bw2data==3.6.6",
         "fs==2.4.16",
         "pyomo<=6.6.2",
         "highspy==1.8.0",
         "ipython==8.14.0",
         "jupyterlab",
+        "numpy<2.0.0",
+        "pandas",
         "tqdm",
+        "xlsxwriter",
     ],
+    extras_require={
+        "bw2": [
+            "bw2calc<=1.8.2",
+            "bw2data<=3.9.9",
+        ],
+        "bw25": [
+            "bw2calc>=2.0.0",
+            "bw2data>=4.0.0",
+        ],
+    },
     long_description=long_description,
     long_description_content_type='text/markdown',  # Specify the content type of the README
 )

--- a/tests/sample_database.py
+++ b/tests/sample_database.py
@@ -1,10 +1,11 @@
 import bw2data as bd
 import bw2calc as bc
 import copy
+from pulpo.utils.tests import is_bw25
 
 def setup_test_db():
     # Set the current project to "sample_project"
-    bd.projects.set_current("sample_project")
+    bd.projects.set_current("sample_project_bw2" if is_bw25() else "sample_project")
 
     # Keys
     # Biosphere
@@ -124,15 +125,22 @@ def setup_test_db():
         method.write(flow_list)
 
 def sample_lcia():
-    # Load the technosphere database
-    bd.projects.set_current('sample_project')
+    bd.projects.set_current("sample_project_bw25" if is_bw25() else "sample_project")
     technosphere_db = bd.Database("technosphere")
-    # Perform LCA with FU 1 for all activities
-    act = {act.key: 1 for act in technosphere_db}
-    # Perform Multi-LCA
-    bd.calculation_setups['multiLCA'] = {'inv': [act], 'ia': list(bd.methods)}
-    myMultiLCA = bc.MultiLCA('multiLCA')
-    results = [round(x, 5) for x in myMultiLCA.results[0]]
+
+    if is_bw25():
+        functional_units = {"act": {act.id: 1 for act in technosphere_db}}
+        config = {"impact_categories": list(bd.methods)}
+        data_objs = bd.get_multilca_data_objs(functional_units=functional_units, method_config=config)
+        myMultiLCA = bc.MultiLCA(demands=functional_units, method_config=config, data_objs=data_objs)
+        myMultiLCA.lci()
+        myMultiLCA.lcia()
+        results = [round(myMultiLCA.scores[x], 5) for x in myMultiLCA.scores]
+    else:
+        act = {act.key: 1 for act in technosphere_db}
+        bd.calculation_setups['multiLCA'] = {'inv': [act], 'ia': list(bd.methods)}
+        myMultiLCA = bc.MultiLCA('multiLCA')
+        results = [round(x, 5) for x in myMultiLCA.results[0]]
     return results
 
 def main():

--- a/tests/sample_database.py
+++ b/tests/sample_database.py
@@ -1,7 +1,7 @@
 import bw2data as bd
 import bw2calc as bc
 import copy
-from pulpo.utils.tests import is_bw25
+from pulpo.utils.utils import is_bw25
 
 def setup_test_db():
     # Set the current project to "sample_project"

--- a/tests/sample_database.py
+++ b/tests/sample_database.py
@@ -5,7 +5,7 @@ from pulpo.utils.utils import is_bw25
 
 def setup_test_db():
     # Set the current project to "sample_project"
-    bd.projects.set_current("sample_project_bw2" if is_bw25() else "sample_project")
+    bd.projects.set_current("sample_project_bw25" if is_bw25() else "sample_project")
 
     # Keys
     # Biosphere


### PR DESCRIPTION
### Summary

This update introduces updates to **PULPO** that enable users to work with both **bw2** and **bw25** projects.

### Key Changes
- **Compatibility**:  
  Users can now specify the desired environment during installation via pip:
  - For **bw2**: `pip install pulpo-dev[bw2]`
  - For **bw25**: `pip install pulpo-dev[bw25]`
  - Note: Only one data environment (**bw2** or **bw25**) can be used at a time.

- **Example Notebooks**:  
  Selected showcase notebooks (*electricity* and *hydrogen*) have been updated to be compatible with **bw25**.

- **Unittests**:  
  unittests have been verified to work properly for both **bw2** and **bw25** environments.

- **Documentation**:  
  The `README.md` has been updated to reflect these and other changes.